### PR TITLE
Refer url protocol and npm config to use appropriate proxy agent 

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -30,26 +30,27 @@ export function getVSCodeDownloadUrl(version: string) {
 const HttpsProxyAgent = require('https-proxy-agent');
 const HttpProxyAgent = require('http-proxy-agent');
 
-var PROXY_AGENT = undefined;
-var HTTPS_PROXY_AGENT = undefined;
+let PROXY_AGENT = undefined;
+let HTTPS_PROXY_AGENT = undefined;
+
 if (process.env.npm_config_proxy) {
-    PROXY_AGENT = new HttpProxyAgent(process.env.npm_config_proxy);
-    HTTPS_PROXY_AGENT = new HttpsProxyAgent(process.env.npm_config_proxy);
+	PROXY_AGENT = new HttpProxyAgent(process.env.npm_config_proxy);
+	HTTPS_PROXY_AGENT = new HttpsProxyAgent(process.env.npm_config_proxy);
 }
 if (process.env.npm_config_https_proxy) {
-    HTTPS_PROXY_AGENT = new HttpsProxyAgent(process.env.npm_config_https_proxy);
+	HTTPS_PROXY_AGENT = new HttpsProxyAgent(process.env.npm_config_https_proxy);
 }
 
 export function urlToOptions(url: string): https.RequestOptions {
-    const options: https.RequestOptions = parseUrl(url)
-    if (PROXY_AGENT && options.protocol.startsWith('http:')) {
-        options.agent = PROXY_AGENT;
-    }
+	const options: https.RequestOptions = parseUrl(url);
+	if (PROXY_AGENT && options.protocol.startsWith('http:')) {
+		options.agent = PROXY_AGENT;
+	}
 
-    if (HTTPS_PROXY_AGENT && options.protocol.startsWith('https:')) {
-        options.agent = HTTPS_PROXY_AGENT;
-    }
-    return options;
+	if (HTTPS_PROXY_AGENT && options.protocol.startsWith('https:')) {
+		options.agent = HTTPS_PROXY_AGENT;
+	}
+	return options;
 }
 
 export function downloadDirToExecutablePath(dir: string) {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -30,25 +30,25 @@ export function getVSCodeDownloadUrl(version: string) {
 const HttpsProxyAgent = require('https-proxy-agent');
 const HttpProxyAgent = require('http-proxy-agent');
 
-let PROXY_AGENT = undefined;
-
+var PROXY_AGENT = undefined;
+var HTTPS_PROXY_AGENT = undefined;
 if (process.env.npm_config_proxy) {
-	console.log(`Using proxy ${process.env.npm_config_proxy}`)
-
-	if (process.env.npm_config_proxy.startsWith('http://')) {
-		PROXY_AGENT = new HttpProxyAgent(process.env.npm_config_proxy)
-	} else if (process.env.npm_config_proxy.startsWith('https://')) {
-		PROXY_AGENT = new HttpsProxyAgent(process.env.npm_config_proxy)
-	}
+    PROXY_AGENT = new HttpProxyAgent(process.env.npm_config_proxy);
+}
+if (process.env.npm_config_https_proxy) {
+    HTTPS_PROXY_AGENT = new HttpsProxyAgent(process.env.npm_config_https_proxy);
 }
 
 export function urlToOptions(url: string): https.RequestOptions {
-	const options: https.RequestOptions = parseUrl(url)
-	if (PROXY_AGENT) {
-		options.agent = PROXY_AGENT;
-	}
+    const options: https.RequestOptions = parseUrl(url)
+    if (PROXY_AGENT && url.startsWith('http://')) {
+        options.agent = PROXY_AGENT;
+    }
 
-	return options;
+    if (HTTPS_PROXY_AGENT && url.startsWith('https://')) {
+        options.agent = HTTPS_PROXY_AGENT;
+    }
+    return options;
 }
 
 export function downloadDirToExecutablePath(dir: string) {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -41,11 +41,11 @@ if (process.env.npm_config_https_proxy) {
 
 export function urlToOptions(url: string): https.RequestOptions {
     const options: https.RequestOptions = parseUrl(url)
-    if (PROXY_AGENT && url.startsWith('http://')) {
+    if (PROXY_AGENT && options.protocol.startsWith('http:')) {
         options.agent = PROXY_AGENT;
     }
 
-    if (HTTPS_PROXY_AGENT && url.startsWith('https://')) {
+    if (HTTPS_PROXY_AGENT && options.protocol.startsWith('https:')) {
         options.agent = HTTPS_PROXY_AGENT;
     }
     return options;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -34,6 +34,7 @@ var PROXY_AGENT = undefined;
 var HTTPS_PROXY_AGENT = undefined;
 if (process.env.npm_config_proxy) {
     PROXY_AGENT = new HttpProxyAgent(process.env.npm_config_proxy);
+    HTTPS_PROXY_AGENT = new HttpsProxyAgent(process.env.npm_config_proxy);
 }
 if (process.env.npm_config_https_proxy) {
     HTTPS_PROXY_AGENT = new HttpsProxyAgent(process.env.npm_config_https_proxy);


### PR DESCRIPTION
This PR fixes #4 

## Problem 

I'm using proxy setting like the below

```sh
$ cat ~/.npmrc
proxy=http://xx.xx.xxx.xx:8080/
https-proxy=http://xx.xx.xxx.xx:8080/
```

But vscode-test is not using `HttpsProxyAgent` to request list of stable release version, when proxy address is not started with `https`.
I think it needs to use `HttpsProxyAgent` because it needs to access https protocol url.

- stable release version url: https://update.code.visualstudio.com/api/releases/stable



## Changes

To solve this problem, i refer given `url` to select proper ProxyAgent.

If you got any issue, feel free to contact me :smile:
