### PR TITLE
Fix node dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This module helps you test VS Code extensions.
 
 Supported:
 
-- Node > 8.x
+- Node >= 8.x
 - Windows > Windows Server 2012+ / Win10+ (anything with Powershell > 5.0)
 - macOS
 - Linux


### PR DESCRIPTION
The README specifies `node > 8.x` (strictly greater than 8.x), but the `package.json` specifies `node >= 8.9.3` (greater than or equal to 8.9.3):

https://github.com/microsoft/vscode-test/blob/b8813110b229fa1a524650c16ec521df42b7893d/package.json#L10-L12

I use node 8 so this was important to me that node 8 is supported.

Thanks!