### PR TITLE
Update example code to match current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,29 +31,29 @@ import { runTests, downloadAndUnzipVSCode } from 'vscode-test'
 
 async function go() {
 
-  const extensionPath = path.resolve(__dirname, '../../')
-  const testRunnerPath = path.resolve(__dirname, './suite')
+  const extensionDevelopmentPath = path.resolve(__dirname, '../../')
+  const extensionTestsPath = path.resolve(__dirname, './suite')
   const testWorkspace = path.resolve(__dirname, '../../test-fixtures/fixture1')
 
   /**
    * Basic usage
    */
   await runTests({
-    extensionPath,
-    testRunnerPath,
-    testWorkspace
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [testWorkspace1]
   })
 
-  const testRunnerPath2 = path.resolve(__dirname, './suite2')
+  const extensionTestsPath2 = path.resolve(__dirname, './suite2')
   const testWorkspace2 = path.resolve(__dirname, '../../test-fixtures/fixture2')
 
   /**
    * Running a second test suite
    */
   await runTests({
-    extensionPath,
-    testRunnerPath: testRunnerPath2,
-    testWorkspace: testWorkspace2
+    extensionDevelopmentPath,
+    extensionTestsPath: extensionTestsPath2,
+    launchArgs: [testWorkspace2]
   })
 
   /**
@@ -61,9 +61,9 @@ async function go() {
    */
   await runTests({
     version: '1.31.0',
-    extensionPath,
-    testRunnerPath,
-    testWorkspace
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [testWorkspace]
   })
 
   /**
@@ -71,47 +71,43 @@ async function go() {
    */
   await runTests({
     version: 'insiders',
-    extensionPath,
-    testRunnerPath,
-    testWorkspace
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [testWorkspace]
   })
 
   /**
-   * Manually download VS Code 1.30.0 release for testing.
+   * Manually download VS Code 1.31.0 release for testing.
+   * Noop, since 1.31.0 already downloaded by the previous command to '.vscode-test/vscode-1.31.0'.
+   */
+  await downloadAndUnzipVSCode('1.31.0')
+
+  /**
+   * Manually download VS Code 1.30.0 release and run tests on it.
    */
   const vscodeExecutablePath = await downloadAndUnzipVSCode('1.30.0')
   await runTests({
     vscodeExecutablePath,
-    extensionPath,
-    testRunnerPath,
-    testWorkspace
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [testWorkspace]
   })
 
   /**
-   * - Add additional launch flags for VS Code
-   * - Pass custom environment variables to test runner
+   * - Add additional launch flags for VS Code.
+   * - Pass custom environment variables to test runner.
    */
   await runTests({
     vscodeExecutablePath,
-    extensionPath,
-    testRunnerPath,
-    testWorkspace,
-    // This disables all extensions except the one being tested
-    additionalLaunchArgs: ['--disable-extensions'],
-    // Custom environment variables for test runner
-    testRunnerEnv: { foo: 'bar' }
-  })
-
-  /**
-   * Manually specify all launch flags for VS Code
-   */
-  await runTests({
-    vscodeExecutablePath,
+    extensionDevelopmentPath,
+    extensionTestsPath,
     launchArgs: [
       testWorkspace,
-      `--extensionDevelopmentPath=${extensionPath}`,
-      `--extensionTestsPath=${testRunnerPath}`
-    ]
+      // This disables all extensions except the one being testing.
+      '--disable-extensions'
+    ],
+    // Custom environment variables for extension test script.
+    extensionTestsEnv: { foo: 'bar' }
   })
 }
 


### PR DESCRIPTION
This updates the example code in README.md to match the [sample/test/runTest.ts](https://github.com/microsoft/vscode-test/blob/669ba6db18fbd36474d2a9ff520ab71d542b25c5/sample/test/runTest.ts) (and thus the current API).