### PR TITLE
runTests: propagate signal when subprocess terminated

### DIFF
--- a/lib/runTest.ts
+++ b/lib/runTest.ts
@@ -125,10 +125,12 @@ async function innerRunTests(
 			console.log('Test error: ' + data.toString());
 		});
 
-		cmd.on('close', function(code) {
+		cmd.on('close', function(code, signal) {
 			console.log(`Exit code:   ${code}`);
 
-			if (code !== 0) {
+			if (code === null) {
+				reject(signal);
+			} else if (code !== 0) {
 				reject('Failed');
 			}
 


### PR DESCRIPTION
While investigating a SIGSEGV which intermittently terminates an
invocation of

```
.vscode-test/vscode-1.42.1/VSCode-linux-x64/code
 --disable-extensions --extensionDevelopmentPath=$DEVELOPMENT_PATH \
 --extensionTestsPath=$EXTENSION_TESTS_PATH/index;
```

spawned by `vscode-test`, I found it desirable to determine whether
the test runner was terminating due to test failures or that SIGSEGV
signal. In general, I think it would be useful for the `vscode-test`
client to have this information.

The [documentation][1] says:
```
If the process terminated due to receipt of a signal, signal is the
string name of the signal, otherwise null. One of the two [i.e. `code`
and `signal`] will always be non-null.
```

[1]: https://nodejs.org/api/child_process.html#child_process_event_exit