### PR TITLE
Show progress while downloading archive

### DIFF
--- a/sample/package.json
+++ b/sample/package.json
@@ -3,6 +3,7 @@
 	"displayName": "vscode-test-sample",
 	"description": "",
 	"version": "0.0.1",
+	"private": "true",
 	"engines": {
 		"vscode": "^1.32.0"
 	},

--- a/sample/package.json
+++ b/sample/package.json
@@ -3,7 +3,6 @@
 	"displayName": "vscode-test-sample",
 	"description": "",
 	"version": "0.0.1",
-	"private": "true",
 	"engines": {
 		"vscode": "^1.32.0"
 	},


### PR DESCRIPTION
- Show progress while downloading archive

![Vscode progress](https://user-images.githubusercontent.com/20282546/86608328-fe0ec780-bfc7-11ea-8466-54215fffb534.gif)

Sometimes on situations like slow network speeds or when download got stuck, it is difficult to interpret whats happening. showing a progress will help.

I am not sure whether to add ext. dependencies, hence added simple progress. 
If it is okay to use ext. libraries. there are options like `node-progress`, `cli-progress` etc. I will replace the progress with it.