### PR TITLE
Avoid calling resolve after reject

### DIFF
--- a/lib/runTest.ts
+++ b/lib/runTest.ts
@@ -183,10 +183,10 @@ async function innerRunTests(
 				reject(signal);
 			} else if (code !== 0) {
 				reject('Failed');
+			} else {
+			        console.log('Done\n');
+			        resolve(code ?? -1);
 			}
-
-			console.log('Done\n');
-			resolve(code ?? -1);
 		}
 
 		cmd.on('close', onProcessClosed);


### PR DESCRIPTION
The implementation of `runTests` returns a promise that, in case of failure, invokes **both** the `resolve` and `reject` callbacks. It looks like a bug and this PR fixes that.
https://github.com/microsoft/vscode-test/blob/8e8d7a872ff6f01f818ee031fd5704233442f663/lib/runTest.ts#L182-L189
