### PR TITLE
Enable downloading a particular insider commit.

### DIFF
--- a/lib/download.ts
+++ b/lib/download.ts
@@ -14,7 +14,7 @@ import * as del from './del';
 import { ConsoleReporter, ProgressReporter, ProgressReportStage } from './progress';
 import * as request from './request';
 import {
-	downloadDirToExecutablePath, getLatestInsidersMetadata, getVSCodeDownloadUrl, insidersDownloadDirMetadata, insidersDownloadDirToExecutablePath, systemDefaultPlatform
+	downloadDirToExecutablePath, getLatestInsidersMetadata, getVSCodeDownloadUrl, insidersDownloadDirMetadata, insidersDownloadDirToExecutablePath, isStableVersionIdentifier, systemDefaultPlatform
 } from './util';
 
 const extensionRoot = process.cwd();
@@ -236,9 +236,12 @@ export async function download(options: Partial<DownloadOptions> = {}): Promise<
 					throw Error(`Failed to remove outdated Insiders at ${downloadedPath}.`);
 				}
 			}
-		} else {
+		} else if (isStableVersionIdentifier(version)) {
 			reporter.report({ stage: ProgressReportStage.FoundMatchingInstall, downloadedPath });
 			return Promise.resolve(downloadDirToExecutablePath(downloadedPath, platform));
+		} else {
+			reporter.report({ stage: ProgressReportStage.FoundMatchingInstall, downloadedPath });
+			return Promise.resolve(insidersDownloadDirToExecutablePath(downloadedPath, platform))
 		}
 	}
 
@@ -259,10 +262,10 @@ export async function download(options: Partial<DownloadOptions> = {}): Promise<
 	}
 	reporter.report({ stage: ProgressReportStage.NewInstallComplete, downloadedPath })
 
-	if (version === 'insiders') {
-		return Promise.resolve(insidersDownloadDirToExecutablePath(downloadedPath, platform));
-	} else {
+	if (isStableVersionIdentifier(version)) {
 		return downloadDirToExecutablePath(downloadedPath, platform);
+	} else {
+		return insidersDownloadDirToExecutablePath(downloadedPath, platform);
 	}
 }
 

--- a/lib/download.ts
+++ b/lib/download.ts
@@ -20,6 +20,7 @@ import {
 const extensionRoot = process.cwd();
 
 const vscodeStableReleasesAPI = `https://update.code.visualstudio.com/api/releases/stable`;
+const vscodeInsiderCommitsAPI = (platform: string) => `https://update.code.visualstudio.com/api/commits/insider/${platform}`;
 
 const DOWNLOAD_ATTEMPTS = 3;
 
@@ -32,9 +33,20 @@ async function fetchLatestStableVersion(): Promise<string> {
 	return versions[0];
 }
 
-async function isValidVersion(version: string) {
-	const validVersions: string[] = await request.getJSON(vscodeStableReleasesAPI);
-	return version === 'insiders' || validVersions.indexOf(version) !== -1;
+async function isValidVersion(version: string, platform: string) {
+	if (version === 'insiders') {
+		return true;
+	}
+
+	const stableVersionNumbers: string[] = await request.getJSON(vscodeStableReleasesAPI);
+	if (stableVersionNumbers.includes(version)) {
+		return true;
+	}
+
+	const insiderCommits: string[] = await request.getJSON(vscodeInsiderCommitsAPI(platform));
+	if (insiderCommits.includes(version)) {
+		return true;
+	}
 }
 
 /**
@@ -185,7 +197,7 @@ export async function download(options: Partial<DownloadOptions> = {}): Promise<
 			 * Only validate version against server when no local download that matches version exists
 			 */
 			if (!fs.existsSync(path.resolve(cachePath, `vscode-${platform}-${version}`))) {
-				if (!(await isValidVersion(version))) {
+				if (!(await isValidVersion(version, platform))) {
 					throw Error(`Invalid version ${version}`);
 				}
 			}

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -40,8 +40,11 @@ switch (process.platform) {
 export function getVSCodeDownloadUrl(version: string, platform = systemDefaultPlatform) {
 	if (version === 'insiders') {
 		return `https://update.code.visualstudio.com/latest/${platform}/insider`;
+	} else if (version === 'stable' || version.includes('.')) { // stable or 1.2.3 version string
+		return `https://update.code.visualstudio.com/${version}/${platform}/stable`;
+	} else { // insiders commit hash
+		return `https://update.code.visualstudio.com/commit:${version}/${platform}/insider`;
 	}
-	return `https://update.code.visualstudio.com/${version}/${platform}/stable`;
 }
 
 let PROXY_AGENT: createHttpProxyAgent.HttpProxyAgent | undefined = undefined;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -37,10 +37,14 @@ switch (process.platform) {
 			: 'linux-x64';
 }
 
+export function isStableVersionIdentifier(version: string): boolean {
+	return version === 'stable' || version.includes('.');  // stable or 1.2.3 version string
+}
+
 export function getVSCodeDownloadUrl(version: string, platform = systemDefaultPlatform) {
 	if (version === 'insiders') {
 		return `https://update.code.visualstudio.com/latest/${platform}/insider`;
-	} else if (version === 'stable' || version.includes('.')) { // stable or 1.2.3 version string
+	} else if (isStableVersionIdentifier(version)) {
 		return `https://update.code.visualstudio.com/${version}/${platform}/stable`;
 	} else { // insiders commit hash
 		return `https://update.code.visualstudio.com/commit:${version}/${platform}/insider`;

--- a/sample/test/runTest.ts
+++ b/sample/test/runTest.ts
@@ -49,6 +49,16 @@ async function go() {
 		});
 
 		/**
+		 * Use a specific Insiders commit for testing
+		 */
+		await runTests({
+			version: '9d3fbb3d9a50055be0a8c6d721625d02c9de492d',
+			extensionDevelopmentPath,
+			extensionTestsPath,
+			launchArgs: [testWorkspace]
+		});
+
+		/**
 		 * Noop, since 1.36.1 already downloaded to .vscode-test/vscode-1.36.1
 		 */
 		await downloadAndUnzipVSCode('1.36.1');


### PR DESCRIPTION
Useful when the latest insiders is broken, and you can't test against stable.

If you are ok with this feature, I will add docs and tests