### PR TITLE
feat: use existing local installs if update service is inaccessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.2.4 | 2022-02-19
+
+- Use existing downloads if internet is inaccessible
+
 ### 2.2.3 | 2022-01-30
 
 - Fix tests sometimes hanging on windows

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -176,3 +176,8 @@ export function resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath: str
 
 	return args;
 }
+
+/** Predicates whether arg is undefined or null */
+export function isDefined<T>(arg: T | undefined | null): arg is T {
+	return arg != null;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/test-electron",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",


### PR DESCRIPTION
While hiking/biking/boating on vacation, I often would not have network access, which prevented tests from running unless I manually specified a version.

Instead, if `stable` is given, the update service is inaccessible, and there is a stable version already downloaded on-disk, emit a warning and use that.

Fixes https://github.com/microsoft/vscode-test/issues/51