### PR TITLE
feat: automatically use vscode version matching engine

### DIFF
--- a/lib/download.test.ts
+++ b/lib/download.test.ts
@@ -1,19 +1,32 @@
 import { spawnSync } from 'child_process';
 import { existsSync, promises as fs } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
-import { afterAll, beforeAll, describe, expect, test } from 'vitest';
-import { downloadAndUnzipVSCode } from './download';
+import { dirname, join } from 'path';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import {
+	downloadAndUnzipVSCode,
+	fetchInsiderVersions,
+	fetchStableVersions,
+	fetchTargetInferredVersion,
+} from './download';
 import { SilentReporter } from './progress';
 import { resolveCliPathFromVSCodeExecutablePath, systemDefaultPlatform } from './util';
 
-const platforms = ['darwin', 'darwin-arm64', 'win32-archive', 'win32-x64-archive', 'linux-x64', 'linux-arm64', 'linux-armhf'];
+const platforms = [
+	'darwin',
+	'darwin-arm64',
+	'win32-archive',
+	'win32-x64-archive',
+	'linux-x64',
+	'linux-arm64',
+	'linux-armhf',
+];
 
 describe('sane downloads', () => {
 	const testTempDir = join(tmpdir(), 'vscode-test-download');
 
 	beforeAll(async () => {
-		await fs.mkdir(testTempDir, { recursive: true })
+		await fs.mkdir(testTempDir, { recursive: true });
 	});
 
 	for (const platform of platforms) {
@@ -39,7 +52,7 @@ describe('sane downloads', () => {
 				expect(version.status).to.equal(0);
 				expect(version.stdout.toString().trim()).to.not.be.empty;
 			}
-		})
+		});
 	}
 
 	afterAll(async () => {
@@ -48,5 +61,81 @@ describe('sane downloads', () => {
 		} catch {
 			// ignored
 		}
+	});
+});
+
+describe('fetchTargetInferredVersion', () => {
+	let stable: string[];
+	let insiders: string[];
+	let extensionsDevelopmentPath = join(tmpdir(), 'vscode-test-tmp-workspace');
+
+	beforeAll(async () => {
+		[stable, insiders] = await Promise.all([fetchStableVersions(5000), fetchInsiderVersions(5000)]);
+	});
+
+	afterEach(async () => {
+		await fs.rm(extensionsDevelopmentPath, { recursive: true, force: true });
+	});
+
+	const writeJSON = async (path: string, contents: object) => {
+		const target = join(extensionsDevelopmentPath, path);
+		await fs.mkdir(dirname(target), { recursive: true });
+		await fs.writeFile(target, JSON.stringify(contents));
+	};
+
+	const doFetch = (paths = ['./']) =>
+		fetchTargetInferredVersion({
+			cachePath: join(extensionsDevelopmentPath, '.cache'),
+			platform: 'win32-archive',
+			timeout: 5000,
+			extensionsDevelopmentPath: paths.map(p => join(extensionsDevelopmentPath, p)),
+		});
+
+	test('matches stable if no workspace', async () => {
+		const version = await doFetch();
+		expect(version).to.equal(stable[0]);
+	});
+
+	test('matches stable by default', async () => {
+		await writeJSON('package.json', {});
+		const version = await doFetch();
+		expect(version).to.equal(stable[0]);
+	});
+
+	test('matches if stable is defined', async () => {
+		await writeJSON('package.json', { engines: { vscode: '^1.50.0' } });
+		const version = await doFetch();
+		expect(version).to.equal(stable[0]);
+	});
+
+	test('matches best', async () => {
+		await writeJSON('package.json', { engines: { vscode: '<=1.60.5' } });
+		const version = await doFetch();
+		expect(version).to.equal('1.60.2');
+	});
+
+	test('matches multiple workspaces', async () => {
+		await writeJSON('a/package.json', { engines: { vscode: '<=1.60.5' } });
+		await writeJSON('b/package.json', { engines: { vscode: '<=1.55.5' } });
+		const version = await doFetch(['a', 'b']);
+		expect(version).to.equal('1.55.2');
+	});
+
+	test('matches insiders to better stable if there is one', async () => {
+		await writeJSON('package.json', { engines: { vscode: '^1.60.0-insider' } });
+		const version = await doFetch();
+		expect(version).to.equal(stable[0]);
+	});
+
+	test('matches current insiders', async () => {
+		await writeJSON('package.json', { engines: { vscode: `^${insiders[0]}` } });
+		const version = await doFetch();
+		expect(version).to.equal(insiders[0]);
+	});
+
+	test('matches insiders to exact', async () => {
+		await writeJSON('package.json', { engines: { vscode: '1.60.0-insider' } });
+		const version = await doFetch();
+		expect(version).to.equal('1.60.0-insider');
 	});
 });

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",
     "jszip": "^3.10.1",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.8"
   },
   "devDependencies": {
     "@types/node": "^18",
     "@types/rimraf": "^3.0.0",
+    "@types/semver": "^7.3.13",
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.13.0",
     "eslint": "^7.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,6 +119,11 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/semver@^7.3.13":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
 "@typescript-eslint/eslint-plugin@^4.13.0":
   version "4.13.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.13.0.tgz"
@@ -1184,6 +1189,13 @@ semver@^7.2.1, semver@^7.3.2:
   version "7.3.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
Automatically use the latest version of VS Code that satisfies all constraints in `engines.vscode` in `package.json`. (But only use Insiders if no stable build satisfies the constraints.)

This also lets users pass `X.Y.Z-insider` to runTests, where previously it was only possible to request the latest Insiders version.

Fixes #176