### PR TITLE
fix: download cli correctly for linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.3.2 | 2022-05-11
+
+- Fix download method not working for the vscode cli.
+
 ### 2.3.1 | 2022-04-04
 
 - Gracefully kill VS Code if SIGINT is received

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",
-    "prepublish": "tsc -p ./",
+    "prepack": "tsc -p ./",
     "fmt": "prettier --write \"lib/**/*.ts\" \"*.md\"",
     "test": "eslint lib --ext ts && vitest && tsc --noEmit",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/test-electron",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",


### PR DESCRIPTION
I'm using this package for some smoke tests involving the CLI. Slight tweak is necessary.