### PR TITLE
Fix insiders version string check

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -37,7 +37,7 @@ switch (process.platform) {
 }
 
 export function isInsiderVersionIdentifier(version: string): boolean {
-	return version === 'insider' || version.endsWith('-insider'); // insider or 1.2.3-insider version string
+	return version === 'insiders' || version.endsWith('-insider'); // insider or 1.2.3-insider version string
 }
 
 export function isStableVersionIdentifier(version: string): boolean {


### PR DESCRIPTION
121fe1f6ecba08a22d7ae753c19a8bef5e7ded7c accidentally changed this from 'insiders' to 'insider'. As a result, if a downloaded insiders build is found, it is never re-downloaded