### PR TITLE
fix: build

### DIFF
--- a/lib/download.ts
+++ b/lib/download.ts
@@ -33,8 +33,6 @@ const pipelineAsync = promisify(pipeline);
 
 const vscodeStableReleasesAPI = `https://update.code.visualstudio.com/api/releases/stable`;
 const vscodeInsiderReleasesAPI = `https://update.code.visualstudio.com/api/releases/insider`;
-const vscodeInsiderCommitsAPI = (platform: string) =>
-	`https://update.code.visualstudio.com/api/commits/insider/${platform}`;
 
 const downloadDirNameFormat = /^vscode-(?<platform>[a-z]+)-(?<version>[0-9.]+)$/;
 const makeDownloadDirName = (platform: string, version: string) => `vscode-${platform}-${version}`;
@@ -155,10 +153,11 @@ async function isValidVersion(version: string, platform: string, timeout: number
 		}
 	}
 
-	const insiderCommits: string[] = await request.getJSON(vscodeInsiderCommitsAPI(platform), timeout);
-	if (insiderCommits.includes(version)) {
+	if (/^[0-9a-f]{40}$/.test(version)) {
 		return true;
 	}
+
+	return false;
 }
 
 /**

--- a/sample/src/test/runTest.ts
+++ b/sample/src/test/runTest.ts
@@ -4,116 +4,111 @@ import * as cp from 'child_process';
 import { runTests, downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '../../..';
 
 async function go() {
-	try {
-		const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
-		const extensionTestsPath = path.resolve(__dirname, './suite');
+	const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
+	const extensionTestsPath = path.resolve(__dirname, './suite');
 
-		/**
-		 * Basic usage
-		 */
+	/**
+	 * Basic usage
+	 */
+	await runTests({
+		extensionDevelopmentPath,
+		extensionTestsPath,
+	});
+
+	const extensionTestsPath2 = path.resolve(__dirname, './suite2');
+	const testWorkspace = path.resolve(__dirname, '../../src/test-fixtures/fixture1');
+
+	/**
+	 * Running another test suite on a specific workspace
+	 */
+	await runTests({
+		extensionDevelopmentPath,
+		extensionTestsPath: extensionTestsPath2,
+		launchArgs: [testWorkspace],
+	});
+
+	/**
+	 * Use 1.36.1 release for testing
+	 */
+	await runTests({
+		version: '1.36.1',
+		extensionDevelopmentPath,
+		extensionTestsPath,
+		launchArgs: [testWorkspace],
+	});
+
+	/**
+	 * Use Insiders release for testing
+	 */
+	await runTests({
+		version: 'insiders',
+		extensionDevelopmentPath,
+		extensionTestsPath,
+		launchArgs: [testWorkspace],
+	});
+
+	/**
+	 * Use a specific Insiders commit for testing
+	 */
+	await runTests({
+		version: '9d3fbb3d9a50055be0a8c6d721625d02c9de492d',
+		extensionDevelopmentPath,
+		extensionTestsPath,
+		launchArgs: [testWorkspace],
+	});
+
+	/**
+	 * Noop, since 1.36.1 already downloaded to .vscode-test/vscode-1.36.1
+	 */
+	await downloadAndUnzipVSCode('1.36.1');
+
+	/**
+	 * Manually download VS Code 1.35.0 release for testing.
+	 */
+	const vscodeExecutablePath = await downloadAndUnzipVSCode('1.35.0');
+	await runTests({
+		vscodeExecutablePath,
+		extensionDevelopmentPath,
+		extensionTestsPath,
+		launchArgs: [testWorkspace],
+	});
+
+	/**
+	 * Install Python extension
+	 */
+	const [cli, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+	cp.spawnSync(cli, [...args, '--install-extension', 'ms-python.python'], {
+		encoding: 'utf-8',
+		stdio: 'inherit',
+	});
+
+	/**
+	 * - Add additional launch flags for VS Code
+	 * - Pass custom environment variables to test runner
+	 */
+	await runTests({
+		vscodeExecutablePath,
+		extensionDevelopmentPath,
+		extensionTestsPath,
+		launchArgs: [
+			testWorkspace,
+			// This disables all extensions except the one being testing
+			'--disable-extensions',
+		],
+		// Custom environment variables for extension test script
+		extensionTestsEnv: { foo: 'bar' },
+	});
+
+	/**
+	 * Use win64 instead of win32 for testing Windows
+	 */
+	if (process.platform === 'win32') {
 		await runTests({
-			extensionDevelopmentPath,
-			extensionTestsPath
-		});
-
-		const extensionTestsPath2 = path.resolve(__dirname, './suite2');
-		const testWorkspace = path.resolve(__dirname, '../../src/test-fixtures/fixture1');
-
-		/**
-		 * Running another test suite on a specific workspace
-		 */
-		await runTests({
-			extensionDevelopmentPath,
-			extensionTestsPath: extensionTestsPath2,
-			launchArgs: [testWorkspace]
-		});
-
-		/**
-		 * Use 1.36.1 release for testing
-		 */
-		await runTests({
-			version: '1.36.1',
 			extensionDevelopmentPath,
 			extensionTestsPath,
-			launchArgs: [testWorkspace]
+			version: '1.40.0',
+			platform: 'win32-x64-archive',
 		});
-
-		/**
-		 * Use Insiders release for testing
-		 */
-		await runTests({
-			version: 'insiders',
-			extensionDevelopmentPath,
-			extensionTestsPath,
-			launchArgs: [testWorkspace]
-		});
-
-		/**
-		 * Use a specific Insiders commit for testing
-		 */
-		await runTests({
-			version: '9d3fbb3d9a50055be0a8c6d721625d02c9de492d',
-			extensionDevelopmentPath,
-			extensionTestsPath,
-			launchArgs: [testWorkspace]
-		});
-
-		/**
-		 * Noop, since 1.36.1 already downloaded to .vscode-test/vscode-1.36.1
-		 */
-		await downloadAndUnzipVSCode('1.36.1');
-
-		/**
-		 * Manually download VS Code 1.35.0 release for testing.
-		 */
-		const vscodeExecutablePath = await downloadAndUnzipVSCode('1.35.0');
-		await runTests({
-			vscodeExecutablePath,
-			extensionDevelopmentPath,
-			extensionTestsPath,
-			launchArgs: [testWorkspace]
-		});
-
-		/**
-		 * Install Python extension
-		 */
-		const [cli, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
-		cp.spawnSync(cli, [...args, '--install-extension', 'ms-python.python'], {
-			encoding: 'utf-8',
-			stdio: 'inherit'
-		});
-
-		/**
-		 * - Add additional launch flags for VS Code
-		 * - Pass custom environment variables to test runner
-		 */
-		await runTests({
-			vscodeExecutablePath,
-			extensionDevelopmentPath,
-			extensionTestsPath,
-			launchArgs: [
-				testWorkspace,
-				// This disables all extensions except the one being testing
-				'--disable-extensions'
-			],
-			// Custom environment variables for extension test script
-			extensionTestsEnv: { foo: 'bar' }
-		});
-
-		/**
-		 * Use win64 instead of win32 for testing Windows
-		 */
-		if (process.platform === 'win32') {
-			await runTests({
-				extensionDevelopmentPath,
-				extensionTestsPath,
-				version: '1.40.0',
-				platform: 'win32-x64-archive'
-			});
-		}
-	} catch (err) {
-		console.error('Failed to run tests');
-		process.exit(1);
 	}
 }
 


### PR DESCRIPTION
At some point the update server started only returning recent commits
from the "commits" API. Which makes good sense, and we should be less
restrictive and try to download any version that looks like a git hash.