### PR TITLE
fix: avoid faulty rename when installing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.3.6 | 2022-10-24
+
+- Fix windows sometimes failing on EPERM in download (again)
+
 ### 2.3.5 | 2022-10-04
 
 - Fix windows sometimes failing on EPERM in download

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/test-electron",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",


### PR DESCRIPTION
Fixes #233, which Andrea ran into when testing.

Instead of staging and renaming, which tends to fail on Windows, write a 'completed' file when the install is done.