### PR TITLE
feat: add length/hash validation for downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.3.7 | 2022-11-23
+
+- Remove detection for unsupported win32 builds
+- Add length and hash validation for downloaded builds
+
 ### 2.3.6 | 2022-10-24
 
 - Fix windows sometimes failing on EPERM in download (again)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-test/issues/246 (possibly)
though it requires https://github.com/microsoft/vscode-update-server/issues/167
in order to be fully functional. At minimum it validates the length of
the stream matches the content-length the CDN told us about, and it
will validate SHA256 checksums when the update server provides them.

(I looked at getting them other ways, but it's very roundabout; the
update server should just add them on all its headers.)