### PR TITLE
fix: compile with node 20, test with 16

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -4,7 +4,6 @@ trigger:
   branches:
     include:
       - main
-pr: none
 
 resources:
   repositories:
@@ -30,11 +29,6 @@ extends:
           - script: yarn --frozen-lockfile
             displayName: Install dependencies
 
-        testPlatforms:
-          - name: Linux
-            nodeVersions:
-              - 16.x
-
         testSteps:
           - script: yarn --frozen-lockfile
             displayName: Install dependencies
@@ -47,6 +41,11 @@ extends:
               echo ">>> Started xvfb"
             displayName: Start xvfb
             condition: eq(variables['Agent.OS'], 'Linux')
+
+          - task: NodeTool@0
+            displayName: Switch to Node 16
+            inputs:
+              versionSpec: 16.x
 
           - script: yarn --cwd=sample test
             displayName: Test package

--- a/sample/package.json
+++ b/sample/package.json
@@ -33,7 +33,7 @@
 		"@types/vscode": "^1.52.0",
 		"glob": "^10.3.10",
 		"mocha": "^8.2.1",
-		"typescript": "^4.1.3"
+		"typescript": "^5.4.5"
 	},
 	"dependencies": {}
 }

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -762,10 +762,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^5.4.5:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes compatibility issues with version bumps in the last PR. We're good to use Node 20 to lint and such, just switch to the min version (16) for running tests. This is needed to publish.