### PR TITLE
fix: throw a well-typed error on run failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### TBA
+
+- Throw a typed `TestRunFailedError` on failure instead of a string.
+
 ### 2.4.0 | 2024-05-24
 
 - Allow installing unreleased builds using an `-unreleased` suffix, such as `insiders-unreleased`.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 export { download, downloadAndUnzipVSCode, DownloadOptions } from './download';
-export { runTests, TestOptions } from './runTest';
+export { runTests, TestOptions, TestRunFailedError } from './runTest';
 export {
 	resolveCliPathFromVSCodeExecutablePath,
 	resolveCliArgsFromVSCodeExecutablePath,

--- a/lib/runTest.ts
+++ b/lib/runTest.ts
@@ -161,13 +161,10 @@ async function innerRunTests(
 			cmd.stdout.destroy();
 			cmd.stderr.destroy();
 
-			if (code === null) {
-				reject(signal);
-			} else if (code !== 0) {
-				reject('Failed');
+			if (code !== 0) {
+				reject(new TestRunFailedError(code ?? undefined, signal ?? undefined));
 			} else {
-				console.log('Done\n');
-				resolve(code ?? -1);
+				resolve(0);
 			}
 		}
 
@@ -189,4 +186,10 @@ async function innerRunTests(
 	}
 
 	return code;
+}
+
+export class TestRunFailedError extends Error {
+	constructor(public readonly code: number | undefined, public readonly signal: string | undefined) {
+		super(signal ? `Test run terminated with signal ${signal}` : `Test run failed with code ${code}`);
+	}
 }


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode-test-cli/issues/44