### PR TITLE
fix: avoid 'Invalid extraction directory' when unzipping

### DIFF
--- a/lib/download.ts
+++ b/lib/download.ts
@@ -383,6 +383,10 @@ async function unzipVSCode(
 				// darwin or *nix sync
 				await pipelineAsync(stream, fs.createWriteStream(stagingFile));
 				await checksum;
+
+				// unzip does not create intermediate directories when using -d
+				await fs.promises.mkdir(extractDir, { recursive: true });
+
 				await spawnDecompressorChild('unzip', ['-q', stagingFile, '-d', extractDir]);
 			}
 		} finally {


### PR DESCRIPTION
Added a line that ensures `extractDir` exists before attempting to unzip to it on macOS and Linux platforms. On macOS version 15.3.2, `unzip` does not create intermediate directories. Based on some [brief research](https://askubuntu.com/questions/1155509/is-it-possible-to-unzip-documents-into-a-directory-which-is-created-on-the-fly-i), this seems to be the case for at least some Linux varieties as well.

This was causing an `Invalid extraction directory` error to occur every time I tried to debug a VSCode extension using the test-cli. The error occurs even for a freshly made project using `npx --package yo --package generator-code -- yo code`:

```console
steven@MacBookPro vscode-unzip-test % npx vscode-test
✔ Validated version: 1.98.2
✔ Found at https://update.code.visualstudio.com/1.98.2/darwin-arm64/stable?released=true
⠋ Downloading VS Code: 129.25/131.43MB (98%)Invalid extraction directory
✖ Error downloading, retrying (attempt 1 of 3): Failed to unzip archive, exited with 10
✔ Found at https://update.code.visualstudio.com/1.98.2/darwin-arm64/stable?released=true
⠏ Downloading VS Code: 129.68/131.43MB (99%)Invalid extraction directory
✖ Error downloading, retrying (attempt 3 of 3): Failed to unzip archive, exited with 10
✔ Found at https://update.code.visualstudio.com/1.98.2/darwin-arm64/stable?released=true
⠏ Downloading VS Code: 131.17/131.43MB (100%)Invalid extraction directory
✖ Error: Error: Failed to unzip archive, exited with 10
Error: Failed to download and unzip VS Code 1.98.2
    at download (/Users/steven/Projects/vscode-unzip-test/node_modules/@vscode/test-electron/out/download.js:396:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async downloadAndUnzipVSCode (/Users/steven/Projects/vscode-unzip-test/node_modules/@vscode/test-electron/out/download.js:409:12)
    at async Module.runTests (/Users/steven/Projects/vscode-unzip-test/node_modules/@vscode/test-electron/out/runTest.js:42:40)
    at async PreparedDesktopRun.run (file:///Users/steven/Projects/vscode-unzip-test/node_modules/@vscode/test-cli/out/cli/platform/desktop.mjs:74:20)
    at async runPreparedConfigs (file:///Users/steven/Projects/vscode-unzip-test/node_modules/@vscode/test-cli/out/bin.mjs:118:31)
    at async main (file:///Users/steven/Projects/vscode-unzip-test/node_modules/@vscode/test-cli/out/bin.mjs:34:20)
```
Edit: The error also occurs when using the sample provided in this repo, so it's not an upstream issue.

Furthermore, upon cloning this repository, 8 of the tests were failing every time.

<details><summary>Without Fix: 8 Tests Failing</summary>
<img width="523" alt="without-fix" src="https://github.com/user-attachments/assets/4b9c639f-0297-48a4-a456-45320e79ce66" />
</details>

After this change, all tests consistently pass:

<img width="752" alt="with-fix" src="https://github.com/user-attachments/assets/e731231d-4144-4359-a604-340c8161430e" />