### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
+.editorconfig
+.eslintrc.js
+.github
 .vscode
 .npmignore
 lib/


### PR DESCRIPTION
This pull request updates the `.npmignore` file to exclude additional configuration and metadata files from the published package. Smaller package size :-)

* [`.npmignore`](diffhunk://#diff-34958b02363eec9a904716f0b4a8782b021c6b33b2e8599019e36c88e045240bR1-R3): Added `.editorconfig`, `.eslintrc.js`, and `.github` to the ignore list to ensure these files are not included in the npm package.