### PR TITLE
Fix space handling on Windows

### DIFF
--- a/lib/runTest.ts
+++ b/lib/runTest.ts
@@ -139,8 +139,12 @@ async function innerRunTests(
 	},
 ): Promise<number> {
 	const fullEnv = Object.assign({}, process.env, testRunnerEnv);
-	const shell = process.platform === 'win32';
-	const cmd = cp.spawn(shell ? `"${executable}"` : executable, args, { env: fullEnv, shell });
+	const shell = process.platform === 'win32' && executable.endsWith('.cmd');
+	if (shell) {
+		executable = `"${executable}"`;
+		args = args.map((arg) => `"${arg}"`);
+	}
+	const cmd = cp.spawn(executable, args, { env: fullEnv, shell });
 
 	let exitRequested = false;
 	const ctrlc1 = () => {


### PR DESCRIPTION
Fixes #298 

After the [fix](https://github.com/microsoft/vscode-test/commit/3f7a3cc5c537957d55fa9e6aeab9d860f7a60078) for [CVE-2024-27980](https://nvd.nist.gov/vuln/detail/CVE-2024-27980), on Windows, the spawn call was changed to be shell-based. As a consequence, the parameters were taken verbatim, and no escaping was done anymore - thus breaking paths with spaces.

In this MR, I improve space handling on Windows in two ways:
1. I disable shell-spawning on Windows in cases where this is not needed; it is only needed for `server` platforms as those run through a `.cmd` file.
2. When we need to go through the shell, I escape all arguments with `""` to ensure that any spaces or other characters are handled properly.

This is still not a perfect solution, since CMD-escaping is very hard. In addition, this does not fully deal with [DEP0190](https://nodejs.org/api/deprecations.html#dep0190-passing-args-to-nodechild_process-execfilespawn-with-shell-option), which discourages using `args` for `shell: true` entirely.