### PR TITLE
fix: don't let a mid-download stream error crash the process

### DIFF
--- a/lib/download.ts
+++ b/lib/download.ts
@@ -352,6 +352,9 @@ async function unzipVSCode(
 ) {
 	const stagingFile = path.join(tmpdir(), `vscode-test-${Date.now()}.zip`);
 	const checksum = validateStream(stream, length, sha256);
+	// `checksum` rejects if the download stream errors, but it's only awaited on the
+	// success paths below — observe it here so a failure can't crash the process.
+	checksum.catch(() => {});
 
 	if (format === 'zip') {
 		const stripComponents = isPlatformServer(platform) ? 1 : 0;


### PR DESCRIPTION
### Summary

A transient error on the VS Code download stream (e.g. an `ECONNRESET` partway through the ~240 MB transfer) crashes the process with an **unhandled promise rejection**, defeating the built-in download retry. The run dies on the first blip even though `download()` is supposed to make 3 attempts.

### Repro

Run any download (`runTests`, `downloadAndUnzipVSCode`, the CLI) on a flaky connection so the archive stream aborts mid-transfer. Observed output:

```
- Downloading (242.87 MB)
✖ Error downloading, retrying (attempt 1 of 3): aborted
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
    ^
Error: aborted
    at TLSSocket.socketCloseListener (node:_http_client:553:19)
    ...
  code: 'ECONNRESET'
```

Note the retry message ("attempt 1 of 3") prints, but the process is then killed by an unhandled rejection before attempt 2 can run.

### Root cause

In `unzipVSCode` (`lib/download.ts`), the checksum-validation promise is created up front but only `await`ed on the success paths:

```ts
const checksum = validateStream(stream, length, sha256);
...
// win32 zip path:
const [buffer, JSZip] = await Promise.all([streamToBuffer(stream), import('jszip')]);
await checksum; // only reached if the line above didn't throw
```

`validateStream` and `streamToBuffer` both attach their own `error` listener to the same `stream`. When the stream aborts:

- `streamToBuffer` rejects → `Promise.all` rejects → awaited → caught by the retry loop in `download()` (this is the "attempt 1 of 3" message).
- `validateStream` (`checksum`) **also** rejects, but the `await checksum` line is never reached because the line above threw → its rejection is unobserved → `unhandledRejection` → fatal under Node's default `--unhandled-rejections=throw`.

So the retry loop can't help: the second rejection escapes it entirely as an out-of-band unhandled rejection. The same applies to the non-win32 zip path (`await pipelineAsync(...)` before `await checksum`) and the tgz path.

### Fix

Attach a no-op rejection handler to `checksum` immediately so its rejection is always observed. Real validation errors are still surfaced by the existing `await checksum` calls on the success paths.

```ts
const checksum = validateStream(stream, length, sha256);
checksum.catch(() => {});
```