### PR TITLE
chore: update TS and exclude sample from CG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3181,7 +3181,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "main": "./out/index.js",
   "engines": {
-    "node": ">=16"
+    "node": ">=22"
   },
   "dependencies": {
     "http-proxy-agent": "^7.0.2",

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -22,7 +22,7 @@ parameters:
 extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
   parameters:
-    cgIgnoreDirectories: sample
+    cgIgnoreDirectories: sample/.vscode-test
     npmPackages:
       - name: test-electron
         ghCreateTag: false

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -22,6 +22,7 @@ parameters:
 extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
   parameters:
+    cgIgnoreDirectories: sample
     npmPackages:
       - name: test-electron
         ghCreateTag: false


### PR DESCRIPTION
Excludes sample/.vscode-test from CG so that we don't get spammed with CG alerts coming from previous versions of VS Code.