### PR TITLE
3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/test-electron",
-  "version": "2.5.4",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/test-electron",
-      "version": "2.5.4",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/test-electron",
-  "version": "2.5.4",
+  "version": "3.0.0",
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",


### PR DESCRIPTION
This version bump represents several bugfixes, dependency bumps, and the feature to add custom stdout/stderr streams. The version bump is a major version bump due to the engine now requiring Node 22 at minimum.