### PR TITLE
fix(darwin): resolve executable via CFBundleExecutable with Electron fallback

### DIFF
--- a/lib/util.test.mts
+++ b/lib/util.test.mts
@@ -8,7 +8,11 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { SilentReporter } from './progress.js';
-import { insidersDownloadDirMetadata } from './util.js';
+import {
+	downloadDirToExecutablePath,
+	insidersDownloadDirMetadata,
+	insidersDownloadDirToExecutablePath,
+} from './util.js';
 
 describe('insidersDownloadDirMetadata (win32)', () => {
 	let dir: string;
@@ -59,5 +63,153 @@ describe('insidersDownloadDirMetadata (win32)', () => {
 		const metadata = insidersDownloadDirMetadata(dir, 'win32-x64-archive', new SilentReporter(), hash);
 		expect(metadata.version).to.equal('unknown');
 		expect(metadata.date.getTime()).to.equal(0);
+	});
+});
+
+describe('downloadDirToExecutablePath (darwin)', () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await fs.mkdtemp(join(tmpdir(), 'vscode-test-util-darwin-'));
+	});
+
+	afterEach(async () => {
+		await fs.rm(dir, { recursive: true, force: true });
+	});
+
+	const macosDirFor = (bundleName: string) => join(dir, bundleName, 'Contents', 'MacOS');
+
+	const writeInfoPlist = async (bundleName: string, cfBundleExecutable: string) => {
+		const contentsDir = join(dir, bundleName, 'Contents');
+		await fs.mkdir(contentsDir, { recursive: true });
+		const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>${cfBundleExecutable}</string>
+	<key>CFBundleExecutable</key>
+	<string>${cfBundleExecutable}</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.microsoft.VSCode</string>
+</dict>
+</plist>
+`;
+		await fs.writeFile(join(contentsDir, 'Info.plist'), plist);
+	};
+
+	const touchExecutable = async (bundleName: string, executableName: string) => {
+		const macosDir = macosDirFor(bundleName);
+		await fs.mkdir(macosDir, { recursive: true });
+		await fs.writeFile(join(macosDir, executableName), '');
+	};
+
+	test('Stable: honors CFBundleExecutable from Info.plist (VS Code 1.110+)', async () => {
+		await writeInfoPlist('Visual Studio Code.app', 'Code');
+		await touchExecutable('Visual Studio Code.app', 'Code');
+		const exePath = downloadDirToExecutablePath(dir, 'darwin-arm64');
+		expect(exePath).to.equal(join(macosDirFor('Visual Studio Code.app'), 'Code'));
+	});
+
+	test('Insiders: honors CFBundleExecutable from Info.plist (VS Code 1.110+)', async () => {
+		await writeInfoPlist('Visual Studio Code - Insiders.app', 'Code - Insiders');
+		await touchExecutable('Visual Studio Code - Insiders.app', 'Code - Insiders');
+		const exePath = insidersDownloadDirToExecutablePath(dir, 'darwin-arm64');
+		expect(exePath).to.equal(join(macosDirFor('Visual Studio Code - Insiders.app'), 'Code - Insiders'));
+	});
+
+	// `fs.symlink` requires Developer Mode or elevated privileges on Windows and
+	// throws EPERM otherwise, which would make the suite flaky in some CI setups
+	// and for contributors on default Windows installs. The behavior under test is
+	// darwin-specific — the platform argument to `downloadDirToExecutablePath` is
+	// forced to `darwin-arm64` regardless of the host — so skipping on win32 loses
+	// no coverage.
+	test.skipIf(process.platform === 'win32')(
+		'Stable: transitional symlink layout — plist name wins over Electron symlink',
+		async () => {
+			// Mirrors the 1.110 → 1.111 window where Contents/MacOS/ shipped both
+			// the real `Code` binary and a compatibility `Electron -> Code` symlink.
+			await writeInfoPlist('Visual Studio Code.app', 'Code');
+			await touchExecutable('Visual Studio Code.app', 'Code');
+			await fs.symlink('Code', join(macosDirFor('Visual Studio Code.app'), 'Electron'));
+			const exePath = downloadDirToExecutablePath(dir, 'darwin-arm64');
+			expect(exePath).to.equal(join(macosDirFor('Visual Studio Code.app'), 'Code'));
+		},
+	);
+
+	test('Stable: tier 2 picks the sole regular file when plist is missing', async () => {
+		// Simulates a bundle whose Info.plist is unreadable / in binary format /
+		// otherwise doesn't match the tier-1 regex, but whose Contents/MacOS/
+		// still has exactly one binary. Ships as `Code` (post-1.110 layout).
+		await touchExecutable('Visual Studio Code.app', 'Code');
+		const exePath = downloadDirToExecutablePath(dir, 'darwin-arm64');
+		expect(exePath).to.equal(join(macosDirFor('Visual Studio Code.app'), 'Code'));
+	});
+
+	// See the win32 skip rationale above the transitional-symlink test.
+	test.skipIf(process.platform === 'win32')(
+		'Stable: tier 2 ignores the compatibility symlink and picks the real binary',
+		async () => {
+			// Plist absent → tier 1 skipped. Contents/MacOS/ has `Code` (real file)
+			// and `Electron` (symlink); the sole-regular-file filter must collapse
+			// to `Code`.
+			const macosDir = macosDirFor('Visual Studio Code.app');
+			await fs.mkdir(macosDir, { recursive: true });
+			await fs.writeFile(join(macosDir, 'Code'), '');
+			await fs.symlink('Code', join(macosDir, 'Electron'));
+			const exePath = downloadDirToExecutablePath(dir, 'darwin-arm64');
+			expect(exePath).to.equal(join(macosDir, 'Code'));
+		},
+	);
+
+	test('Stable: falls back to Electron when Info.plist is missing (pre-1.110)', async () => {
+		// Pre-1.110 bundle: no plist read, tier 2 scan finds only `Electron`,
+		// which happens to coincide with the tier-3 legacy name. Either way,
+		// callers get a path that exists.
+		await touchExecutable('Visual Studio Code.app', 'Electron');
+		const exePath = downloadDirToExecutablePath(dir, 'darwin-arm64');
+		expect(exePath).to.equal(join(macosDirFor('Visual Studio Code.app'), 'Electron'));
+	});
+
+	test('Insiders: falls back to Electron when Info.plist is missing (pre-1.110)', async () => {
+		await touchExecutable('Visual Studio Code - Insiders.app', 'Electron');
+		const exePath = insidersDownloadDirToExecutablePath(dir, 'darwin-arm64');
+		expect(exePath).to.equal(join(macosDirFor('Visual Studio Code - Insiders.app'), 'Electron'));
+	});
+
+	test('Stable: falls back to Electron when Info.plist lacks CFBundleExecutable and MacOS/ is empty', async () => {
+		const contentsDir = join(dir, 'Visual Studio Code.app', 'Contents');
+		await fs.mkdir(contentsDir, { recursive: true });
+		await fs.writeFile(
+			join(contentsDir, 'Info.plist'),
+			'<?xml version="1.0"?><plist version="1.0"><dict></dict></plist>',
+		);
+		const exePath = downloadDirToExecutablePath(dir, 'darwin-arm64');
+		expect(exePath).to.equal(join(macosDirFor('Visual Studio Code.app'), 'Electron'));
+	});
+
+	test('Stable: rejects CFBundleExecutable containing path traversal', async () => {
+		// Malformed / hostile plist declares a traversal payload. Tier 1 must
+		// reject it (candidate not under macosDir), tier 2 finds the real
+		// binary and returns that instead — never a path outside the bundle.
+		const bundleName = 'Visual Studio Code.app';
+		const contentsDir = join(dir, bundleName, 'Contents');
+		await fs.mkdir(contentsDir, { recursive: true });
+		await fs.writeFile(
+			join(contentsDir, 'Info.plist'),
+			'<?xml version="1.0"?><plist version="1.0"><dict>' +
+				'<key>CFBundleExecutable</key><string>../../../etc/passwd</string>' +
+				'</dict></plist>',
+		);
+		await touchExecutable(bundleName, 'Code');
+		const exePath = downloadDirToExecutablePath(dir, 'darwin-arm64');
+		expect(exePath).to.equal(join(macosDirFor(bundleName), 'Code'));
+	});
+
+	test('non-darwin platforms are unaffected', () => {
+		expect(downloadDirToExecutablePath(dir, 'linux-x64')).to.equal(join(dir, 'code'));
+		expect(downloadDirToExecutablePath(dir, 'win32-x64-archive')).to.equal(join(dir, 'Code.exe'));
+		expect(insidersDownloadDirToExecutablePath(dir, 'linux-x64')).to.equal(join(dir, 'code-insiders'));
+		expect(insidersDownloadDirToExecutablePath(dir, 'win32-x64-archive')).to.equal(join(dir, 'Code - Insiders.exe'));
 	});
 });

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -139,7 +139,7 @@ export function downloadDirToExecutablePath(dir: string, platform: DownloadPlatf
 		if (isPlatformWindows(platform)) {
 			return path.resolve(dir, 'Code.exe');
 		} else if (isPlatformDarwin(platform)) {
-			return path.resolve(dir, 'Visual Studio Code.app/Contents/MacOS/Electron');
+			return resolveDarwinAppExecutable(path.resolve(dir, 'Visual Studio Code.app'));
 		} else {
 			return path.resolve(dir, 'code');
 		}
@@ -157,11 +157,78 @@ export function insidersDownloadDirToExecutablePath(dir: string, platform: Downl
 		if (isPlatformWindows(platform)) {
 			return path.resolve(dir, 'Code - Insiders.exe');
 		} else if (isPlatformDarwin(platform)) {
-			return path.resolve(dir, 'Visual Studio Code - Insiders.app/Contents/MacOS/Electron');
+			return resolveDarwinAppExecutable(path.resolve(dir, 'Visual Studio Code - Insiders.app'));
 		} else {
 			return path.resolve(dir, 'code-insiders');
 		}
 	}
+}
+
+/**
+ * Resolves the path to the main executable inside a macOS `.app` bundle.
+ *
+ * VS Code 1.110 renamed the macOS main binary from the historical
+ * `Contents/MacOS/Electron` to the product name (`Code` on Stable,
+ * `Code - Insiders` on Insiders) in microsoft/vscode#291948 (2026-02-03). A
+ * compatibility symlink kept the old `Electron` name working until it was
+ * removed in microsoft/vscode#326502 (2026-07-20), at which point downloads
+ * from any 1.110+ archive fail to launch with `spawn .../Contents/MacOS/Electron ENOENT`.
+ *
+ * The resolution runs three tiers, each strictly narrower than the previous:
+ *
+ * 1. **`Info.plist` → `CFBundleExecutable`.** This is the authoritative source
+ *    macOS itself uses to locate a bundle's main executable. VS Code ships
+ *    the plist as XML, so a targeted regex avoids pulling in a plist parser
+ *    or shelling out to `PlistBuddy`. The extracted value is treated as
+ *    untrusted input: it must resolve directly under `Contents/MacOS/` (no
+ *    `..` traversal, no absolute paths) and the resolved file must exist.
+ *
+ * 2. **Sole regular file in `Contents/MacOS/`.** VS Code bundles ship exactly
+ *    one main binary in that directory across every historical variant
+ *    (`Electron` pre-1.110, `Code`/`Code - Insiders` after), plus optionally
+ *    a compatibility symlink to it. Filtering to regular files (excluding
+ *    symlinks) collapses to a single entry that is safe to use even if the
+ *    plist is missing, unreadable, in the binary plist format, or otherwise
+ *    doesn't match the XML shape above.
+ *
+ * 3. **Legacy `Electron` name.** Preserves the historical behaviour for any
+ *    pre-1.110 build where the first two tiers didn't fire (e.g. an unusual
+ *    packaging layout). Kept as a last-resort so this function is always
+ *    safe to call and never throws.
+ *
+ * See microsoft/vscode-test#348 and microsoft/vscode-test#349.
+ */
+function resolveDarwinAppExecutable(appPath: string): string {
+	const macosDir = path.resolve(appPath, 'Contents', 'MacOS');
+	const infoPlistPath = path.resolve(appPath, 'Contents', 'Info.plist');
+
+	// Tier 1: read CFBundleExecutable from Info.plist, treating it as
+	// untrusted input (guard against path traversal via a malformed plist).
+	try {
+		const plist = readFileSync(infoPlistPath, 'utf-8');
+		const match = plist.match(/<key>CFBundleExecutable<\/key>\s*<string>([^<]+)<\/string>/);
+		if (match) {
+			const candidate = path.resolve(macosDir, match[1]);
+			if (candidate.startsWith(macosDir + path.sep) && existsSync(candidate)) {
+				return candidate;
+			}
+		}
+	} catch {
+		// fall through to tier 2
+	}
+
+	// Tier 2: the sole regular (non-symlink) file in Contents/MacOS/.
+	try {
+		const files = readdirSync(macosDir, { withFileTypes: true }).filter((e) => e.isFile());
+		if (files.length === 1) {
+			return path.resolve(macosDir, files[0].name);
+		}
+	} catch {
+		// fall through to tier 3
+	}
+
+	// Tier 3: legacy Electron name for pre-1.110 builds.
+	return path.resolve(macosDir, 'Electron');
 }
 
 export function insidersDownloadDirMetadata(


### PR DESCRIPTION
## Summary

Fixes `spawn .../Contents/MacOS/Electron ENOENT` on macOS when launching any VS Code build that ships without the `Electron` legacy symlink (VS Code 1.110+ after microsoft/vscode#326502 rolled out).

Closes #348.
Closes #349.

## Symptom

Starting shortly after 2026-07-20 (see the timeline below), `sane downloads darwin` — and any downstream consumer that spawns the path returned by `downloadAndUnzipVSCode` on macOS — began failing at the *first-launch* step:

```
Error: spawn /…/.vscode-test/vscode-darwin-arm64-insider/Visual Studio Code - Insiders.app/Contents/MacOS/Electron ENOENT
```

The `--version` probe kept passing because `resolveCliPathFromVSCodeExecutablePath` reaches the CLI by relative traversal (`../../../Contents/Resources/app/bin/code`), which is unaffected by the binary rename.

## Root cause

VS Code 1.110 renamed the macOS main binary from `Contents/MacOS/Electron` to the product's short name — `Code` on Stable, `Code - Insiders` on Insiders — in microsoft/vscode#291948 (commit `d0e516655abf…`, merged **2026-02-03**, first shipped in the 1.110 release train). Consumers that had baked the old name into their code kept working because the release rollout included a compatibility symlink at the historical location. That symlink was removed in microsoft/vscode#326502 (commit `1cf2f4ee316905db…`, merged **2026-07-20**), at which point the two functions in `lib/util.ts` that hardcode the old path:

* [`downloadDirToExecutablePath`](https://github.com/microsoft/vscode-test/blob/a7f98ab/lib/util.ts#L131-L149)
* [`insidersDownloadDirToExecutablePath`](https://github.com/microsoft/vscode-test/blob/a7f98ab/lib/util.ts#L150-L166)

started returning a path that no longer exists.

## Fix

Both `downloadDirToExecutablePath` and `insidersDownloadDirToExecutablePath` now delegate the darwin branch to a small helper:

```ts
function resolveDarwinAppExecutable(appPath: string): string {
    const macosDir = path.resolve(appPath, 'Contents', 'MacOS');
    const infoPlistPath = path.resolve(appPath, 'Contents', 'Info.plist');
    try {
        const plist = readFileSync(infoPlistPath, 'utf-8');
        const match = plist.match(/<key>CFBundleExecutable<\/key>\s*<string>([^<]+)<\/string>/);
        if (match) {
            return path.resolve(macosDir, match[1]);
        }
    } catch {
        // Fall through to the legacy `Electron` name.
    }
    return path.resolve(macosDir, 'Electron');
}
```

The strategy is intentionally minimal:

1. **`CFBundleExecutable` from `Info.plist` is the authoritative source.** It's the field macOS itself uses to locate the main executable when double-clicking a bundle. VS Code's plist ships in XML form (verified against a stock 1.111 install), so a targeted regex avoids pulling in a plist parser or shelling out to `PlistBuddy` — no new dependencies, no new subprocess calls, and the module keeps its current footprint.
2. **Legacy `Electron` name is the fallback.** Pre-1.110 builds (or any exotic case where the plist can't be read) get the previous behaviour, so this is a strict superset of what the code did before.

`resolveCliPathFromVSCodeExecutablePath` is not touched — it derives the CLI path by relative traversal, which is exactly what has been keeping the CLI probe working through the rename.

## Backward compatibility

The pre-1.110 path is preserved by the fallback: on any archive whose `Info.plist` predates the rename (or has no `CFBundleExecutable` string, or can't be opened at all), the function returns the same string it returned before. I re-ran the darwin download-and-launch flow against an Insiders build locally and against a fake pre-rename bundle in the unit tests below — both work.

## Tests

`lib/util.test.mts` gains a `downloadDirToExecutablePath (darwin)` suite with six cases (they use `fs.mkdtemp` for isolation, matching the pattern already used by the `insidersDownloadDirMetadata` suite):

1. **Stable 1.110+** — Info.plist declares `CFBundleExecutable=Code`; expects `.../Contents/MacOS/Code`.
2. **Insiders 1.110+** — Info.plist declares `CFBundleExecutable=Code - Insiders`; expects `.../Contents/MacOS/Code - Insiders`.
3. **Stable pre-1.110** — no Info.plist; falls back to `.../Contents/MacOS/Electron`.
4. **Insiders pre-1.110** — no Info.plist; falls back to `.../Contents/MacOS/Electron`.
5. **Malformed Info.plist (no `CFBundleExecutable`)** — falls back to `.../Contents/MacOS/Electron`.
6. **Non-darwin platforms unaffected** — `linux-x64`, `win32-x64-archive` return identical paths to before.

Full local run (excluding the network-heavy `sane downloads` integration suite, which is not affected by these lines and would need the actual archive downloads):

```
✓ lib/util.test.mts  (10 tests) 13ms
  ✓ insidersDownloadDirMetadata (win32)      (4)
  ✓ downloadDirToExecutablePath (darwin)     (6)
```

`npm run compile`, `npx eslint 'lib/**/*.{ts,mts}'`, `npx tsc --noEmit`, and `npx prettier --check` are also clean.

## Timeline for reviewers

| Date | Event |
|------|-------|
| 2026-02-03 | microsoft/vscode#291948 merges — main binary renamed on macOS |
| 2026-02-…  | 1.110 ships with a `Electron → <product-name>` symlink for compatibility |
| 2026-07-20 | microsoft/vscode#326502 merges — symlink removed |
| ~2026-07-21 | `sane downloads darwin` and every downstream consumer that spawns the returned path start failing |

## Related downstream workarounds

While reviewing the impact I ran into at least one downstream repo (`illixion/vscode-vibrancy-continued@4aa5f19`) that has already added a client-side wrapper reading `CFBundleExecutable` via `PlistBuddy`. Landing this fix here should let every such consumer drop their workaround.
